### PR TITLE
Update slack invite link as is on linktr.ee

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Cloud technical track of Women Who Code is a community dedicated to inspirin
 
 Join our community conversations!
 
-[Slack](https://join.slack.com/t/wwcodecloud/shared_invite/zt-fsr8x4av-mmSMyzczGiKjBdKAODs0Dg)  
+[Slack](https://join.slack.com/t/wwcodecloud/shared_invite/zt-lngnes83-iq8TuBLOtAGXnHFaM5~sTw)  
 [Twitter](https://twitter.com/wwcodecloud)  
 [Instagram](https://www.instagram.com/wwcodecloud/)  
 [Facebook](https://www.facebook.com/Women-Who-Code-Cloud-147081753767317)  


### PR DESCRIPTION
Hi, the link to join WWCode Cloud slack was leading me the wrong path, since it is not valid anymore.
I found the current active link through https://linktr.ee/wwcodecloud

The left shows the link that is currently on the repository, and the right shows the link that works and comes from linktr.ee

![on the left link is no longer valid, on the right link is valid](https://user-images.githubusercontent.com/11148726/114109974-5c0d6a00-98ce-11eb-97a8-f33d06a6195d.png)
